### PR TITLE
Create user-defined ordering of subcategories

### DIFF
--- a/artState.js
+++ b/artState.js
@@ -1,4 +1,5 @@
 import Artwork from "./db/models/artwork.js"
+import LinkedList from "./utils/LinkedList.js"
 
 let artWorks = {}
 
@@ -25,6 +26,7 @@ export async function fetchArt() {
             thumbnail: "$thumbnail",
             category: "$category",
             subCategory: "$subCategory",
+            nextArtwork: "$nextArtwork",
           },
         },
       },
@@ -66,7 +68,8 @@ export async function fetchArt() {
   const groupedArt = artworkCollection.reduce((group, { category, subcategories }) => {
     group[category] = {}
     subcategories.forEach(({ subCategory, artworks }) => {
-      group[category][subCategory] = artworks
+      const sortedArt = new LinkedList(artworks)
+      group[category][subCategory] = sortedArt.entries
     })
     return group
   }, {})

--- a/db/models/artwork.js
+++ b/db/models/artwork.js
@@ -6,6 +6,10 @@ const artWorkSchema = new mongoose.Schema({
   thumbnail: String,
   title: String,
   extension: String,
+  nextArtwork: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Artworks",
+  },
 })
 
 const Artwork = new mongoose.model("ArtWork", artWorkSchema)

--- a/db/models/artwork.js
+++ b/db/models/artwork.js
@@ -1,16 +1,24 @@
 import mongoose from "mongoose"
 
 const artWorkSchema = new mongoose.Schema({
-  category: String,
-  subCategory: String,
+  category: {
+    type: String,
+    index: true,
+  },
+  subCategory: {
+    type: String,
+  },
   thumbnail: String,
   title: String,
   extension: String,
   nextArtwork: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "Artworks",
+    index: true,
   },
 })
+
+artWorkSchema.index({ nextArtwork: 1, subCategory: 1, category: 1 })
 
 const Artwork = new mongoose.model("ArtWork", artWorkSchema)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sharp": "^0.32.6",
-        "ssl-express-www": "^3.0.7"
+        "ssl-express-www": "^3.0.7",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "concurrently": "^8.2.1",
@@ -880,6 +881,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "dev": true,
@@ -1182,6 +1191,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
@@ -5290,6 +5309,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -5462,8 +5489,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "^0.32.6",
-    "ssl-express-www": "^3.0.7"
+    "ssl-express-www": "^3.0.7",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "concurrently": "^8.2.1",
@@ -35,5 +36,7 @@
   "author": "",
   "license": "ISC",
   "type": "module",
-  "trustedDependencies": ["sharp"]
+  "trustedDependencies": [
+    "sharp"
+  ]
 }

--- a/public/build/src/index.js
+++ b/public/build/src/index.js
@@ -23472,11 +23472,11 @@ var require_jsx_dev_runtime = __commonJS((exports, module) => {
 });
 
 // src/index.js
-var import_react13 = __toESM(require_react(), 1);
+var import_react14 = __toESM(require_react(), 1);
 var client = __toESM(require_client(), 1);
 
 // src/App.js
-var import_react12 = __toESM(require_react(), 1);
+var import_react13 = __toESM(require_react(), 1);
 
 // src/components/Upload.js
 var import_react7 = __toESM(require_react(), 1);
@@ -24107,7 +24107,7 @@ function Upload() {
 }
 
 // src/components/Delete.jsx
-var import_react11 = __toESM(require_react(), 1);
+var import_react12 = __toESM(require_react(), 1);
 
 // src/components/Edit.js
 var import_react8 = __toESM(require_react(), 1);
@@ -24263,10 +24263,146 @@ var ConfirmationModal = import_react9.forwardRef(function ConfirmationModal2({ o
 var ConfirmationModal_default = ConfirmationModal;
 
 // src/components/EditCarousel.js
+var import_react11 = __toESM(require_react(), 1);
+
+// src/hooks/useArtOrdering.js
 var import_react10 = __toESM(require_react(), 1);
+function useArtOrdering(container, onValidDrop) {
+  const dragGrid = import_react10.useRef();
+  const dropNeighbor = import_react10.useRef();
+  const dragEnabled = import_react10.useRef(false);
+  import_react10.useEffect(() => {
+    children().forEach((dragItem) => {
+      dragItem.addEventListener("dragstart", handleDragStart);
+      dragItem.addEventListener("dragend", handleDragEnd);
+    });
+    return () => {
+      children().forEach((dragItem) => {
+        dragItem.removeEventListener("dragstart", handleDragStart);
+        dragItem.removeEventListener("dragstart", handleDragEnd);
+      });
+    };
+  }, [handleDragStart]);
+  function children() {
+    return Array.from(container.current?.children || []);
+  }
+  function showDropLocation(dropId, dropSide) {
+    const toggleOff = dropSide === "left" ? "right" : "left";
+    children().forEach((child) => {
+      child.classList.toggle(`dragged-${dropSide}-of`, child.dataset.dragid === dropId);
+      child.classList.toggle(`dragged-${toggleOff}-of`, false);
+    });
+  }
+  function getCurrentRow(e) {
+    const { top } = container.current.getBoundingClientRect();
+    const { clientY } = e;
+    const { scrollTop, scrollHeight } = container.current;
+    const rowHeight = scrollHeight / dragGrid.current.length;
+    const mouseY = clientY - top;
+    let row = 0;
+    let currentHeight = rowHeight;
+    while (mouseY + scrollTop > currentHeight) {
+      row++;
+      currentHeight += rowHeight;
+    }
+    return row;
+  }
+  function getCurrentColumn(e, row) {
+    const { left } = container.current.getBoundingClientRect();
+    const { clientX } = e;
+    let column = 0;
+    while (column < dragGrid.current[row]?.length) {
+      const currItem = dragGrid.current[row][column];
+      const midPoint = currItem.left + currItem.width / 2;
+      if (clientX > midPoint)
+        column++;
+      else
+        break;
+    }
+    return column;
+  }
+  function createDragItem(item) {
+    const { left, top, width, height } = item.getBoundingClientRect();
+    return { top, left, height, width, id: item.dataset.dragid };
+  }
+  function nearestNeighbor(row) {
+    if (row === dragGrid.current.length - 1) {
+      return { id: undefined };
+    } else {
+      return dragGrid.current[row + 1][0];
+    }
+  }
+  function handleDragStart(e) {
+    e.stopPropagation();
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text", e.currentTarget.dataset.dragid);
+    dragEnabled.current = true;
+    const rows = new Set;
+    const dragItemGrid = [];
+    const dragItems = children();
+    dragItems.forEach((dragItem) => {
+      const { top } = dragItem.getBoundingClientRect();
+      rows.add(top);
+    });
+    let itemIndex = 0;
+    let rowIndex = 0;
+    for (const row of rows) {
+      while (dragItems[itemIndex]?.getBoundingClientRect()?.top === row) {
+        const newDragItem = createDragItem(dragItems[itemIndex]);
+        dragItemGrid[rowIndex] ||= [];
+        dragItemGrid[rowIndex].push(newDragItem);
+        itemIndex++;
+      }
+      rowIndex++;
+    }
+    dragGrid.current = dragItemGrid;
+  }
+  function handleDragEnd(e) {
+    container.current.style.outline = "none";
+    dragEnabled.current = false;
+  }
+  function handleDragOver(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer.effectAllowed !== "move" || !dragEnabled.current) {
+      e.dataTransfer.effectAllowed = "none";
+      return;
+    }
+    e.dataTransfer.dropEffect = "move";
+    e.currentTarget.style.outline = "auto";
+    const row = getCurrentRow(e);
+    const column = getCurrentColumn(e, row);
+    const neighbor = dragGrid.current[row][column];
+    const dropId = neighbor?.id || dragGrid.current[row].at(-1)?.id;
+    const dropSide = neighbor ? "left" : "right";
+    showDropLocation(dropId, dropSide);
+    dropNeighbor.current = neighbor || nearestNeighbor(row);
+  }
+  function handleDragLeave(e) {
+    e.currentTarget.style.outline = "unset";
+    showDropLocation(null, "left");
+  }
+  function handleDrop(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!dragEnabled.current)
+      return;
+    const draggedItemid = e.dataTransfer.getData("text");
+    console.log({ draggedItemid });
+    console.log({ neighborId: dropNeighbor.current.id });
+    showDropLocation(null, "left");
+  }
+  return {
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop
+  };
+}
+
+// src/components/EditCarousel.js
 var jsx_dev_runtime9 = __toESM(require_jsx_dev_runtime(), 1);
 function EditCarousel({ artworks, activeArt, onChange }) {
-  const editCarouselScroll = import_react10.useRef();
+  const editCarouselScroll = import_react11.useRef();
   const handleFocus = (e) => {
     const { offsetTop, offsetHeight: imgHeight } = e.target.parentElement;
     const { offsetHeight, scrollTop, scrollHeight } = editCarouselScroll.current;
@@ -24277,6 +24413,7 @@ function EditCarousel({ artworks, activeArt, onChange }) {
       behavior: "smooth"
     });
   };
+  const orderingProps = useArtOrdering(editCarouselScroll);
   return jsx_dev_runtime9.jsxDEV("fieldset", {
     children: [
       jsx_dev_runtime9.jsxDEV("legend", {
@@ -24296,8 +24433,10 @@ function EditCarousel({ artworks, activeArt, onChange }) {
           jsx_dev_runtime9.jsxDEV("div", {
             className: "thumbnail-list edit-carousel",
             ref: editCarouselScroll,
+            ...orderingProps,
             children: artworks.map(({ _id, thumbnail, title }) => jsx_dev_runtime9.jsxDEV("label", {
               className: "edit-carousel-item",
+              "data-dragid": _id,
               children: [
                 jsx_dev_runtime9.jsxDEV("img", {
                   className: `thumbnail-image img ${activeArt?._id === _id ? "img-clicked" : ""}`,
@@ -24325,13 +24464,13 @@ function EditCarousel({ artworks, activeArt, onChange }) {
 // src/components/Delete.jsx
 var jsx_dev_runtime10 = __toESM(require_jsx_dev_runtime(), 1);
 function Delete() {
-  const { artWorks, dispatch } = import_react11.useContext(ArtworkContext);
-  const [category, setCategory] = import_react11.useState("");
-  const [subCategory, setSubCategory] = import_react11.useState("");
-  const [activeArt, setActiveArt] = import_react11.useState(null);
-  const [deleting, setDeleting] = import_react11.useState(false);
+  const { artWorks, dispatch } = import_react12.useContext(ArtworkContext);
+  const [category, setCategory] = import_react12.useState("");
+  const [subCategory, setSubCategory] = import_react12.useState("");
+  const [activeArt, setActiveArt] = import_react12.useState(null);
+  const [deleting, setDeleting] = import_react12.useState(false);
   const { setAlert } = useAlerts();
-  const dialogRef = import_react11.useRef();
+  const dialogRef = import_react12.useRef();
   const updateActiveArt = (_id) => {
     if (_id === activeArt?._id)
       return setActiveArt(null);
@@ -24587,4 +24726,4 @@ function App({ artWorks }) {
 var container = document.getElementById("artwork-admin");
 var artWorks = JSON.parse(container.getAttribute("data-state"));
 var root = client.default.createRoot(container);
-root.render(import_react13.default.createElement(App, { artWorks }));
+root.render(import_react14.default.createElement(App, { artWorks }));

--- a/public/build/src/index.js
+++ b/public/build/src/index.js
@@ -23666,11 +23666,58 @@ var AlertsReducer = function(state, action) {
 };
 var AlertContext = import_react2.createContext();
 
+// node_modules/uuid/dist/esm-browser/rng.js
+var getRandomValues;
+var rnds8 = new Uint8Array(16);
+function rng() {
+  if (!getRandomValues) {
+    getRandomValues = typeof crypto !== "undefined" && crypto.getRandomValues && crypto.getRandomValues.bind(crypto);
+    if (!getRandomValues) {
+      throw new Error("crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported");
+    }
+  }
+  return getRandomValues(rnds8);
+}
+
+// node_modules/uuid/dist/esm-browser/stringify.js
+function unsafeStringify(arr, offset = 0) {
+  return byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + "-" + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + "-" + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + "-" + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + "-" + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]];
+}
+var byteToHex = [];
+for (let i = 0;i < 256; ++i) {
+  byteToHex.push((i + 256).toString(16).slice(1));
+}
+
+// node_modules/uuid/dist/esm-browser/native.js
+var randomUUID = typeof crypto !== "undefined" && crypto.randomUUID && crypto.randomUUID.bind(crypto);
+var native_default = {
+  randomUUID
+};
+
+// node_modules/uuid/dist/esm-browser/v4.js
+var v4 = function(options, buf, offset) {
+  if (native_default.randomUUID && !buf && !options) {
+    return native_default.randomUUID();
+  }
+  options = options || {};
+  const rnds = options.random || (options.rng || rng)();
+  rnds[6] = rnds[6] & 15 | 64;
+  rnds[8] = rnds[8] & 63 | 128;
+  if (buf) {
+    offset = offset || 0;
+    for (let i = 0;i < 16; ++i) {
+      buf[offset + i] = rnds[i];
+    }
+    return buf;
+  }
+  return unsafeStringify(rnds);
+};
+var v4_default = v4;
 // src/hooks/useAlerts.js
 function useAlerts(alertDuration = 7000) {
   const { dispatch, alerts } = import_react3.useContext(AlertContext);
   function setAlert({ message, type }) {
-    const id = Math.random();
+    const id = v4_default();
     const timeout = setAlertTimeout(id);
     dispatch({ type: "NEW_ALERT", payload: { id, message, type, timeout } });
   }
@@ -24429,7 +24476,9 @@ function useArtOrdering(container, onValidDrop) {
 var jsx_dev_runtime9 = __toESM(require_jsx_dev_runtime(), 1);
 function EditCarousel({ artworks, activeArt, onChange }) {
   const { dispatch } = import_react11.useContext(ArtworkContext);
+  const [reordering, setReordering] = import_react11.useState(false);
   const editCarouselScroll = import_react11.useRef();
+  const { setAlert } = useAlerts();
   const handleFocus = (e) => {
     const { offsetTop, offsetHeight: imgHeight } = e.target.parentElement;
     const { offsetHeight, scrollHeight } = editCarouselScroll.current;
@@ -24440,13 +24489,26 @@ function EditCarousel({ artworks, activeArt, onChange }) {
       behavior: "smooth"
     });
   };
-  const handleArtReorder = (itemId, neighborId) => {
-    const newList = new LinkedList(artworks);
-    newList.moveListItem(itemId, neighborId);
-    dispatch({
-      type: "REORDER_ART",
-      payload: newList.entries
-    });
+  const handleArtReorder = async (itemId, neighborId) => {
+    setReordering(true);
+    const originalState = [...artworks.map((art) => ({ ...art }))];
+    try {
+      const newList = new LinkedList(artworks);
+      newList.moveListItem(itemId, neighborId);
+      dispatch({
+        type: "REORDER_ART",
+        payload: newList.entries
+      });
+      await new Promise((resolve, reject) => setTimeout(reject, 1000));
+    } catch (error) {
+      setAlert({ type: "danger", message: "There was an error reordering the artwork" });
+      dispatch({
+        type: "REORDER_ART",
+        payload: originalState
+      });
+    } finally {
+      setReordering(false);
+    }
   };
   const orderingProps = useArtOrdering(editCarouselScroll, handleArtReorder);
   return jsx_dev_runtime9.jsxDEV("fieldset", {
@@ -24466,7 +24528,7 @@ function EditCarousel({ artworks, activeArt, onChange }) {
             children: artworks[0].subCategory
           }, undefined, false, undefined, this),
           jsx_dev_runtime9.jsxDEV("div", {
-            className: "thumbnail-list edit-carousel",
+            className: `thumbnail-list edit-carousel ${reordering ? "drop-pending" : ""}`,
             ref: editCarouselScroll,
             ...orderingProps,
             children: artworks.map(({ _id, thumbnail, title }) => jsx_dev_runtime9.jsxDEV("label", {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -304,10 +304,16 @@ ul.thumbnail-list {
   flex-wrap: wrap;
   align-content: flex-start;
   max-height: 300px;
+  min-height: 0;
   width: 100%;
   overflow-y: auto;
   margin: 0;
-  padding: 0.5rem;
+  padding: 0.75rem;
+  outline-offset: 4px;
+}
+
+.edit-carousel-item {
+  transition: translate 150ms;
 }
 
 .current-subcategory--header {
@@ -896,12 +902,34 @@ label.radio {
 
 .img-clicked {
   outline: auto;
-  outline-offset: 4px;
 }
 
 .active-art-card {
   display: grid;
   justify-items: center;
+}
+
+.dragged-left-of {
+  translate: 8px 0;
+}
+
+.dragged-left-of::before,
+.dragged-right-of::before {
+  content: "";
+  position: absolute;
+  right: calc(100% + 8px);
+  height: 100%;
+  width: 4px;
+  border-radius: 2px;
+  background-color: white;
+}
+
+.dragged-right-of::before {
+  left: calc(100% + 8px);
+}
+
+[data-dragid] {
+  cursor: grab;
 }
 
 /* MEDIA QUERY TABLET SIZE */

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -917,7 +917,7 @@ label.radio {
 .dragged-right-of::before {
   content: "";
   position: absolute;
-  right: calc(100% + 8px);
+  right: calc(100% + 10px);
   height: 100%;
   width: 4px;
   border-radius: 2px;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -312,8 +312,24 @@ ul.thumbnail-list {
   outline-offset: 4px;
 }
 
+.edit-carousel.drop-pending {
+  cursor: progress;
+}
+
+.edit-carousel.drop-pending .edit-carousel-item {
+  opacity: 0.9;
+  pointer-events: none;
+}
+
 .edit-carousel-item {
-  transition: translate 150ms;
+  transition:
+    translate 150ms,
+    opacity 75ms;
+  cursor: pointer;
+}
+
+.edit-carousel-item:hover {
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 .current-subcategory--header {
@@ -647,6 +663,7 @@ label {
   min-height: 250px;
 }
 
+.edit-carousel-item button,
 .image-preview-container button {
   background: transparent;
   display: flex;
@@ -887,14 +904,14 @@ label.radio {
   display: none !important;
 }
 
-.img {
-  transition: opacity 75ms;
-}
-
-.img:hover {
-  cursor: pointer;
-  opacity: 75%;
-}
+/* .img { */
+/*   transition: opacity 75ms; */
+/* } */
+/**/
+/* .img:hover { */
+/*   cursor: pointer; */
+/*   opacity: 75%; */
+/* } */
 
 .fa-check {
   display: none;
@@ -928,9 +945,9 @@ label.radio {
   left: calc(100% + 8px);
 }
 
-[data-dragid] {
-  cursor: grab;
-}
+/* [data-dragid] { */
+/*   cursor: grab; */
+/* } */
 
 /* MEDIA QUERY TABLET SIZE */
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -25,7 +25,7 @@ apiRouter.post("/artwork", uploader, async (req, res) => {
     const prevArt = await Artwork.findOneAndUpdate(
       { category, subCategory, nextArtwork: null, _id: { $ne: newArt._id } },
       { $set: { nextArtwork: newArt._id } },
-      { new: true }
+      { new: true },
     )
     await newArt.save()
     console.log("Finished uploading new image to collection:", title)
@@ -54,7 +54,7 @@ apiRouter.delete("/artwork", async (req, res) => {
     const prevArt = await Artwork.findOneAndUpdate(
       { category: art.category, subCategory: art.subCategory, nextArtwork: art._id },
       { $set: { nextArtwork: art.nextArtwork } },
-      { new: true }
+      { new: true },
     )
 
     fetchArt()
@@ -86,7 +86,7 @@ apiRouter.put("/artwork", async (req, res) => {
     const updatedArt = await Artwork.findOneAndUpdate(
       { _id: oldImg._id },
       { thumbnail, title, subCategory, category, nextArtwork },
-      { new: true }
+      { new: true },
     )
     let prevArt, newLocationPrev
     prevArt = await Artwork.findOneAndUpdate(
@@ -97,12 +97,12 @@ apiRouter.put("/artwork", async (req, res) => {
         _id: { $ne: newImg._id },
       },
       { nextArtwork: oldImg.nextArtwork },
-      { new: true }
+      { new: true },
     )
     newLocationPrev = await Artwork.findOneAndUpdate(
       { category, subCategory, nextArtwork, _id: { $ne: newImg._id } },
       { nextArtwork: newImg._id },
-      { new: true }
+      { new: true },
     )
     fetchArt()
     res.status(201).json({ updatedArt, prevArt, newLocationPrev })
@@ -126,7 +126,11 @@ apiRouter.patch("/artwork", async (req, res) => {
     )
     // Update the new left neighbor to point to movedArt
     await Artwork.findOneAndUpdate(
-      { nextArtwork: neighborArt?._id || null, subCategory: movedArt.subCategory },
+      {
+        nextArtwork: neighborArt?._id || null,
+        subCategory: movedArt.subCategory,
+        category: movedArt.category,
+      },
       { nextArtwork: movedArt._id },
       { session },
     )

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -48,9 +48,16 @@ pageRouter.post("/login", async (req, res) => {
       }
     })
   })
-  // const salt = await bcrypt.genSalt(10)
-  // const newPass = await bcrypt.hash(password, salt)
-  // await User.findOneAndUpdate({ username }, { password: newPass })
+  // try {
+  //   const salt = await bcrypt.genSalt(10)
+  //   const newPass = await bcrypt.hash(password, salt)
+  //   const user = new User({ username, password: newPass })
+  //   await user.save()
+  //   res.redirect("/login")
+  // } catch (err) {
+  //   res.send(err.message)
+  //   console.log(err)
+  // }
 })
 
 pageRouter.get("/upload", isAuthenticated, async (req, res) => {
@@ -63,7 +70,7 @@ pageRouter.get("/:category", async (req, res) => {
   let { category } = req.params
   category = capitalize(category)
   const pageCopy = titleDesc.find(item => item.page === category) || {}
-  const artCategory = artWorks[category]
+  const artCategory = artWorks[category] || {}
 
   res.render("template", {
     pageCopy,

--- a/src/components/Delete.jsx
+++ b/src/components/Delete.jsx
@@ -42,8 +42,10 @@ export default function Delete() {
     try {
       const { _id } = activeArt
       const params = new URLSearchParams({ _id }).toString()
-      await fetch("/api/artwork?" + params, { method: "DELETE" })
-      dispatch({ type: "DELETE_ARTWORK", payload: { ...activeArt } })
+      const res = await fetch("/api/artwork?" + params, { method: "DELETE" })
+      const { prevArt } = await res.json()
+      dispatch({ type: "DELETE_ARTWORK", payload: activeArt })
+      dispatch({ type: "UPDATE_ARTWORK", payload: prevArt })
       setAlert({ message: "Successfully deleted artwork!", type: "success" })
       setActiveArt(null)
       setSubCategory("")

--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -25,14 +25,18 @@ export default function Edit({ artWork, onUpdateComplete }) {
     e.preventDefault()
     setUpdating(true)
     try {
-      const body = { oldImg: artWork, newImg: form }
+      const body = { oldImg: artWork, newImg: { ...form, nextArtwork: artWork.nextArtwork } }
       const res = await fetch("/api/artwork/", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       })
-      const updatedArt = await res.json()
+      const { updatedArt, prevArt, newLocationPrev } = await res.json()
       onUpdateComplete()
+
+      console.log({ updatedArt, newLocationPrev, prevArt })
+      dispatch({ type: "UPDATE_ARTWORK", payload: newLocationPrev })
+      dispatch({ type: "UPDATE_ARTWORK", payload: prevArt })
       dispatch({ type: "MOVE_ARTWORK", payload: { ...body, newImg: updatedArt } })
     } catch (error) {
       setAlert({ type: "warning", message: "There was an error updating this artwork" })

--- a/src/components/EditCarousel.js
+++ b/src/components/EditCarousel.js
@@ -1,12 +1,15 @@
-import React, { useRef } from "react"
+import React, { useRef, useContext } from "react"
 import useArtOrdering from "../hooks/useArtOrdering.js"
+import { ArtworkContext } from "../context/ArtworkContext"
+import LinkedList from "../../utils/LinkedList.js"
 
 export default function EditCarousel({ artworks, activeArt, onChange }) {
+  const { dispatch } = useContext(ArtworkContext)
   const editCarouselScroll = useRef()
 
   const handleFocus = e => {
     const { offsetTop, offsetHeight: imgHeight } = e.target.parentElement
-    const { offsetHeight, scrollTop, scrollHeight } = editCarouselScroll.current
+    const { offsetHeight, scrollHeight } = editCarouselScroll.current
     let scrollPosition = offsetTop - (offsetHeight - imgHeight) / 2
     scrollPosition = Math.max(0, Math.min(scrollPosition, scrollHeight - offsetHeight))
     editCarouselScroll.current.scroll({
@@ -15,7 +18,16 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
     })
   }
 
-  const orderingProps = useArtOrdering(editCarouselScroll)
+  const handleArtReorder = (itemId, neighborId) => {
+    const newList = new LinkedList(artworks)
+    newList.moveListItem(itemId, neighborId)
+    dispatch({
+      type: "REORDER_ART",
+      payload: newList.entries,
+    })
+  }
+
+  const orderingProps = useArtOrdering(editCarouselScroll, handleArtReorder)
 
   return (
     <fieldset>

--- a/src/components/EditCarousel.js
+++ b/src/components/EditCarousel.js
@@ -1,4 +1,5 @@
 import React, { useRef } from "react"
+import useArtOrdering from "../hooks/useArtOrdering.js"
 
 export default function EditCarousel({ artworks, activeArt, onChange }) {
   const editCarouselScroll = useRef()
@@ -14,6 +15,8 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
     })
   }
 
+  const orderingProps = useArtOrdering(editCarouselScroll)
+
   return (
     <fieldset>
       <legend>
@@ -23,9 +26,9 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
       </legend>
       <div className="thumbnail-container scrollbar scrollbar-deep-blue ">
         <h3 className="current-subcategory--header">{artworks[0].subCategory}</h3>
-        <div className="thumbnail-list edit-carousel" ref={editCarouselScroll}>
+        <div className="thumbnail-list edit-carousel" ref={editCarouselScroll} {...orderingProps}>
           {artworks.map(({ _id, thumbnail, title }) => (
-            <label key={_id} className="edit-carousel-item">
+            <label key={_id} className="edit-carousel-item" data-dragid={_id}>
               <img
                 className={`thumbnail-image img ${activeArt?._id === _id ? "img-clicked" : ""}`}
                 src={thumbnail}

--- a/src/components/EditCarousel.js
+++ b/src/components/EditCarousel.js
@@ -26,12 +26,24 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
     const originalState = [...artworks.map(art => ({ ...art }))]
     try {
       const newList = new LinkedList(artworks)
-      newList.moveListItem(itemId, neighborId)
+      const artMoved = newList.moveListItem(itemId, neighborId)
+      if (!artMoved) return
+
       dispatch({
         type: "REORDER_ART",
         payload: newList.entries,
       })
-      await new Promise((resolve, reject) => setTimeout(reject, 1000))
+      const movedArt = originalState.find(art => art._id === itemId)
+      const neighborArt = originalState.find(art => art._id === neighborId)
+      const res = await fetch("/api/artwork", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ movedArt, neighborArt }),
+      })
+      if (!res.ok) throw new Error("Error reordering artwork")
+      // await new Promise((resolve, reject) => setTimeout(reject, 1000))
     } catch (error) {
       setAlert({ type: "danger", message: "There was an error reordering the artwork" })
       dispatch({

--- a/src/components/EditCarousel.js
+++ b/src/components/EditCarousel.js
@@ -1,11 +1,14 @@
-import React, { useRef, useContext } from "react"
+import React, { useRef, useContext, useState } from "react"
 import useArtOrdering from "../hooks/useArtOrdering.js"
 import { ArtworkContext } from "../context/ArtworkContext"
 import LinkedList from "../../utils/LinkedList.js"
+import useAlerts from "../hooks/useAlerts.js"
 
 export default function EditCarousel({ artworks, activeArt, onChange }) {
   const { dispatch } = useContext(ArtworkContext)
+  const [reordering, setReordering] = useState(false)
   const editCarouselScroll = useRef()
+  const { setAlert } = useAlerts()
 
   const handleFocus = e => {
     const { offsetTop, offsetHeight: imgHeight } = e.target.parentElement
@@ -18,13 +21,26 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
     })
   }
 
-  const handleArtReorder = (itemId, neighborId) => {
-    const newList = new LinkedList(artworks)
-    newList.moveListItem(itemId, neighborId)
-    dispatch({
-      type: "REORDER_ART",
-      payload: newList.entries,
-    })
+  const handleArtReorder = async (itemId, neighborId) => {
+    setReordering(true)
+    const originalState = [...artworks.map(art => ({ ...art }))]
+    try {
+      const newList = new LinkedList(artworks)
+      newList.moveListItem(itemId, neighborId)
+      dispatch({
+        type: "REORDER_ART",
+        payload: newList.entries,
+      })
+      await new Promise((resolve, reject) => setTimeout(reject, 1000))
+    } catch (error) {
+      setAlert({ type: "danger", message: "There was an error reordering the artwork" })
+      dispatch({
+        type: "REORDER_ART",
+        payload: originalState,
+      })
+    } finally {
+      setReordering(false)
+    }
   }
 
   const orderingProps = useArtOrdering(editCarouselScroll, handleArtReorder)
@@ -38,7 +54,11 @@ export default function EditCarousel({ artworks, activeArt, onChange }) {
       </legend>
       <div className="thumbnail-container scrollbar scrollbar-deep-blue ">
         <h3 className="current-subcategory--header">{artworks[0].subCategory}</h3>
-        <div className="thumbnail-list edit-carousel" ref={editCarouselScroll} {...orderingProps}>
+        <div
+          className={`thumbnail-list edit-carousel ${reordering ? "drop-pending" : ""}`}
+          ref={editCarouselScroll}
+          {...orderingProps}
+        >
           {artworks.map(({ _id, thumbnail, title }) => (
             <label key={_id} className="edit-carousel-item" data-dragid={_id}>
               <img

--- a/src/components/Upload.js
+++ b/src/components/Upload.js
@@ -45,7 +45,8 @@ export default function Upload() {
         method: "POST",
         body: uploadForm,
       })
-      const { newArt } = await res.json()
+      const { newArt, prevArt } = await res.json()
+      dispatch({ type: "UPDATE_ARTWORK", payload: prevArt })
       dispatch({ type: "ADD_ARTWORK", payload: newArt })
       setAlert({ message: "Successfully uploaded artwork!", type: "success" })
       e.target.reset()

--- a/src/context/ArtworkContext.js
+++ b/src/context/ArtworkContext.js
@@ -1,5 +1,10 @@
 import { createContext, useReducer } from "react"
-import { addNewArt, removeArt, updateExistingArt } from "../../utils/stateUtils.js"
+import {
+  addNewArt,
+  removeArt,
+  updateExistingArt,
+  reorderSubCategory,
+} from "../../utils/stateUtils.js"
 
 export const ArtworkContext = createContext()
 
@@ -25,6 +30,9 @@ function ArtworkReducer(state, action) {
     }
     case "UPDATE_ARTWORK": {
       return updateExistingArt(state, action.payload)
+    }
+    case "REORDER_ART": {
+      return reorderSubCategory(state, action.payload)
     }
     default:
       return state

--- a/src/context/ArtworkContext.js
+++ b/src/context/ArtworkContext.js
@@ -1,5 +1,5 @@
 import { createContext, useReducer } from "react"
-import { addNewArt, removeArt } from "../../utils/stateUtils.js"
+import { addNewArt, removeArt, updateExistingArt } from "../../utils/stateUtils.js"
 
 export const ArtworkContext = createContext()
 
@@ -22,6 +22,9 @@ function ArtworkReducer(state, action) {
     case "MOVE_ARTWORK": {
       const { newImg, oldImg } = action.payload
       return addNewArt(removeArt(state, oldImg), newImg)
+    }
+    case "UPDATE_ARTWORK": {
+      return updateExistingArt(state, action.payload)
     }
     default:
       return state

--- a/src/hooks/useAlerts.js
+++ b/src/hooks/useAlerts.js
@@ -1,12 +1,12 @@
 import { useContext } from "react"
 import { AlertContext } from "../context/AlertContext"
+import { v4 as uuidv4 } from "uuid"
 
 export default function useAlerts(alertDuration = 7_000) {
   const { dispatch, alerts } = useContext(AlertContext)
 
   function setAlert({ message, type }) {
-    // const id = crypto.randomUUID()
-    const id = Math.random()
+    const id = uuidv4()
     const timeout = setAlertTimeout(id)
 
     dispatch({ type: "NEW_ALERT", payload: { id, message, type, timeout } })
@@ -30,7 +30,7 @@ export default function useAlerts(alertDuration = 7_000) {
         duration: 100,
         easing: "ease-in",
         fill: "forwards",
-      }
+      },
     )
     const slideAnimation = new Animation(slideFrames, document.timeline)
     const collapseAnimation = new Animation(collapseFrames, document.timeline)

--- a/src/hooks/useArtOrdering.js
+++ b/src/hooks/useArtOrdering.js
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from "react"
+
+export default function useArtOrdering(container, onValidDrop) {
+  const dragGrid = useRef()
+  const dropNeighbor = useRef()
+  const dragEnabled = useRef(false)
+
+  useEffect(() => {
+    children().forEach(dragItem => {
+      dragItem.addEventListener("dragstart", handleDragStart)
+      dragItem.addEventListener("dragend", handleDragEnd)
+    })
+
+    return () => {
+      children().forEach(dragItem => {
+        dragItem.removeEventListener("dragstart", handleDragStart)
+        dragItem.removeEventListener("dragstart", handleDragEnd)
+      })
+    }
+  }, [handleDragStart])
+
+  function children() {
+    return Array.from(container.current?.children || [])
+  }
+
+  function showDropLocation(dropId, dropSide) {
+    const toggleOff = dropSide === "left" ? "right" : "left"
+    children().forEach(child => {
+      child.classList.toggle(`dragged-${dropSide}-of`, child.dataset.dragid === dropId)
+      child.classList.toggle(`dragged-${toggleOff}-of`, false)
+    })
+  }
+
+  function getCurrentRow(e) {
+    const { top } = container.current.getBoundingClientRect()
+    const { clientY } = e
+    const { scrollTop, scrollHeight } = container.current
+    const rowHeight = scrollHeight / dragGrid.current.length
+    const mouseY = clientY - top
+
+    let row = 0
+    let currentHeight = rowHeight
+    while (mouseY + scrollTop > currentHeight) {
+      row++
+      currentHeight += rowHeight
+    }
+    return row
+  }
+
+  function getCurrentColumn(e, row) {
+    const { left } = container.current.getBoundingClientRect()
+    const { clientX } = e
+    let column = 0
+    while (column < dragGrid.current[row]?.length) {
+      const currItem = dragGrid.current[row][column]
+      const midPoint = currItem.left + currItem.width / 2
+      if (clientX > midPoint) column++
+      else break
+    }
+    return column
+  }
+
+  function createDragItem(item) {
+    const { left, top, width, height } = item.getBoundingClientRect()
+    return { top, left, height, width, id: item.dataset.dragid }
+  }
+
+  function nearestNeighbor(row) {
+    if (row === dragGrid.current.length - 1) {
+      return { id: undefined }
+    } else {
+      return dragGrid.current[row + 1][0]
+    }
+  }
+
+  function handleDragStart(e) {
+    e.stopPropagation()
+    e.dataTransfer.effectAllowed = "move"
+    e.dataTransfer.setData("text", e.currentTarget.dataset.dragid)
+    dragEnabled.current = true
+
+    const rows = new Set()
+    const dragItemGrid = []
+    const dragItems = children()
+
+    dragItems.forEach(dragItem => {
+      const { top } = dragItem.getBoundingClientRect()
+      rows.add(top)
+    })
+
+    let itemIndex = 0
+    let rowIndex = 0
+
+    for (const row of rows) {
+      while (dragItems[itemIndex]?.getBoundingClientRect()?.top === row) {
+        const newDragItem = createDragItem(dragItems[itemIndex])
+        dragItemGrid[rowIndex] ||= []
+        dragItemGrid[rowIndex].push(newDragItem)
+        itemIndex++
+      }
+
+      rowIndex++
+    }
+    dragGrid.current = dragItemGrid
+  }
+
+  function handleDragEnd(e) {
+    container.current.style.outline = "none"
+    dragEnabled.current = false
+  }
+
+  function handleDragOver(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.dataTransfer.effectAllowed !== "move" || !dragEnabled.current) {
+      e.dataTransfer.effectAllowed = "none"
+      return
+    }
+
+    e.dataTransfer.dropEffect = "move"
+    e.currentTarget.style.outline = "auto"
+
+    const row = getCurrentRow(e)
+    const column = getCurrentColumn(e, row)
+    const neighbor = dragGrid.current[row][column]
+    const dropId = neighbor?.id || dragGrid.current[row].at(-1)?.id
+    const dropSide = neighbor ? "left" : "right"
+
+    showDropLocation(dropId, dropSide)
+
+    dropNeighbor.current = neighbor || nearestNeighbor(row)
+  }
+
+  function handleDragLeave(e) {
+    e.currentTarget.style.outline = "unset"
+    showDropLocation(null, "left")
+  }
+
+  function handleDrop(e) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!dragEnabled.current) return
+
+    const draggedItemid = e.dataTransfer.getData("text")
+    console.log({ draggedItemid })
+    console.log({ neighborId: dropNeighbor.current.id })
+    showDropLocation(null, "left")
+  }
+
+  return {
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  }
+}

--- a/src/hooks/useArtOrdering.js
+++ b/src/hooks/useArtOrdering.js
@@ -20,7 +20,7 @@ export default function useArtOrdering(container, onValidDrop) {
   }, [handleDragStart])
 
   function children() {
-    return Array.from(container.current?.children || [])
+    return Array.from(container?.current?.children || [])
   }
 
   function showDropLocation(dropId, dropSide) {
@@ -33,10 +33,9 @@ export default function useArtOrdering(container, onValidDrop) {
 
   function getCurrentRow(e) {
     const { top } = container.current.getBoundingClientRect()
-    const { clientY } = e
+    const mouseY = e.clientY - top
     const { scrollTop, scrollHeight } = container.current
     const rowHeight = scrollHeight / dragGrid.current.length
-    const mouseY = clientY - top
 
     let row = 0
     let currentHeight = rowHeight
@@ -48,13 +47,12 @@ export default function useArtOrdering(container, onValidDrop) {
   }
 
   function getCurrentColumn(e, row) {
-    const { left } = container.current.getBoundingClientRect()
-    const { clientX } = e
     let column = 0
+
     while (column < dragGrid.current[row]?.length) {
       const currItem = dragGrid.current[row][column]
       const midPoint = currItem.left + currItem.width / 2
-      if (clientX > midPoint) column++
+      if (e.clientX > midPoint) column++
       else break
     }
     return column
@@ -104,7 +102,7 @@ export default function useArtOrdering(container, onValidDrop) {
     dragGrid.current = dragItemGrid
   }
 
-  function handleDragEnd(e) {
+  function handleDragEnd() {
     container.current.style.outline = "none"
     dragEnabled.current = false
   }
@@ -141,10 +139,11 @@ export default function useArtOrdering(container, onValidDrop) {
     e.stopPropagation()
     if (!dragEnabled.current) return
 
-    const draggedItemid = e.dataTransfer.getData("text")
-    console.log({ draggedItemid })
-    console.log({ neighborId: dropNeighbor.current.id })
+    const draggedItemId = e.dataTransfer.getData("text")
     showDropLocation(null, "left")
+    if (draggedItemId === dropNeighbor.current.id) return
+
+    onValidDrop(draggedItemId, dropNeighbor.current.id)
   }
 
   return {

--- a/utils/LinkedList.js
+++ b/utils/LinkedList.js
@@ -1,0 +1,42 @@
+export default class LinkedList {
+  constructor(array) {
+    this.rawList = array
+    // this.head = this.buildList()
+    this.entries = this.orderList()
+  }
+
+  orderList() {
+    let node = this.findHead()
+    const newList = [node]
+    while (node.nextArtwork) {
+      node = this.rawList.find(({ _id }) => _id.toString() === node.nextArtwork.toString())
+      newList.push(node)
+    }
+    return newList
+  }
+
+  // buildList() {
+  //   const head = this.findHead()
+  //   let node = head
+  //   while (node.nextArtwork) {
+  //     const next = this.rawList.find(({ _id }) => _id.toString() === node.nextArtwork.toString())
+  //     node.nextArtwork = next
+  //     node = node.nextArtwork
+  //   }
+  //   return head
+  // }
+
+  findHead() {
+    const nextIds = new Set()
+
+    for (const entry of this.rawList) {
+      nextIds.add(entry.nextArtwork?.toString())
+    }
+    for (const entry of this.rawList) {
+      if (!nextIds.has(entry._id.toString())) {
+        return entry
+      }
+    }
+    return null
+  }
+}

--- a/utils/LinkedList.js
+++ b/utils/LinkedList.js
@@ -8,8 +8,10 @@ export default class LinkedList {
   orderList() {
     let node = this.findHead()
     const newList = [node]
-    while (node.nextArtwork) {
-      node = this.rawList.find(({ _id }) => _id.toString() === node.nextArtwork.toString())
+    while (node?.nextArtwork) {
+      node = this.rawList.find(
+        listNode => listNode?._id?.toString() === node.nextArtwork.toString(),
+      )
       newList.push(node)
     }
     return newList
@@ -25,6 +27,21 @@ export default class LinkedList {
   //   }
   //   return head
   // }
+
+  moveListItem(movedNodeId, neighborNodeId) {
+    const movedNode = this.rawList.findIndex(art => art._id.toString() === movedNodeId)
+    if (this.rawList[movedNode].nextArtwork?.toString() === neighborNodeId) return
+
+    const newNeighbor = this.rawList.findIndex(
+      art => art.nextArtwork?.toString() === neighborNodeId,
+    )
+    const movedNeighbor = this.rawList.findIndex(art => art.nextArtwork?.toString() === movedNodeId)
+    if (movedNeighbor > -1)
+      this.rawList[movedNeighbor].nextArtwork = this.rawList[movedNode].nextArtwork
+    if (newNeighbor > -1) this.rawList[newNeighbor].nextArtwork = movedNodeId
+    this.rawList[movedNode].nextArtwork = neighborNodeId
+    this.entries = this.orderList()
+  }
 
   findHead() {
     const nextIds = new Set()

--- a/utils/LinkedList.js
+++ b/utils/LinkedList.js
@@ -6,13 +6,20 @@ export default class LinkedList {
   }
 
   orderList() {
+    let recursionDepth = 0
     let node = this.findHead()
     const newList = [node]
-    while (node?.nextArtwork) {
+    while (node?.nextArtwork && recursionDepth < this.rawList.length * 2) {
       node = this.rawList.find(
         listNode => listNode?._id?.toString() === node.nextArtwork.toString(),
       )
       newList.push(node)
+      recursionDepth++
+    }
+    if (recursionDepth >= this.rawList.length * 2) {
+      console.error("Recursion depth exceeded")
+      console.log("List: ", this.rawList)
+      console.log("New list: ", newList)
     }
     return newList
   }
@@ -30,7 +37,7 @@ export default class LinkedList {
 
   moveListItem(movedNodeId, neighborNodeId) {
     const movedNode = this.rawList.findIndex(art => art._id.toString() === movedNodeId)
-    if (this.rawList[movedNode].nextArtwork?.toString() === neighborNodeId) return
+    if (this.rawList[movedNode].nextArtwork?.toString() === neighborNodeId) return false
 
     const newNeighbor = this.rawList.findIndex(
       art => art.nextArtwork?.toString() === neighborNodeId,
@@ -41,6 +48,7 @@ export default class LinkedList {
     if (newNeighbor > -1) this.rawList[newNeighbor].nextArtwork = movedNodeId
     this.rawList[movedNode].nextArtwork = neighborNodeId
     this.entries = this.orderList()
+    return true
   }
 
   findHead() {

--- a/utils/stateUtils.js
+++ b/utils/stateUtils.js
@@ -1,20 +1,36 @@
+import LinkedList from "./LinkedList.js"
+
 export function addNewArt(state, payload) {
+  if (!payload) return state
+
   const { category, subCategory } = payload
+  let current = state[category]?.[subCategory] || []
+
+  if (!current.length) current.push(payload)
+  else {
+    const index = current.findIndex(({ _id }) => _id === payload._id)
+    if (index < 0) current.push(payload)
+    else current[index] = payload
+  }
+  const subCategoryList = new LinkedList(current)
+
   return {
     ...state,
     [category]: {
       ...state[category],
-      [subCategory]: [...(state[category][subCategory] || []), payload],
+      [subCategory]: subCategoryList.entries,
     },
   }
 }
 
 export function removeArt(state, payload) {
+  if (!payload) return state
+
   const { category, subCategory, _id } = payload
   let newSubCategory
-  if (state[category][subCategory]?.length <= 1) {
+  if (state[category]?.[subCategory]?.length <= 1) {
     newSubCategory = {}
-    delete state[category][subCategory]
+    delete state[category]?.[subCategory]
   } else {
     newSubCategory = {
       [subCategory]: state[category][subCategory].filter(art => art._id !== _id),
@@ -25,6 +41,26 @@ export function removeArt(state, payload) {
     [category]: {
       ...state[category],
       ...newSubCategory,
+    },
+  }
+}
+
+export function updateExistingArt(state, payload) {
+  if (!payload) return state
+
+  const { category, subCategory } = payload
+  let current = state[category]?.[subCategory] || []
+  const index = current.findIndex(({ _id }) => _id === payload._id)
+
+  if (index < 0) return state
+
+  current[index] = payload
+
+  return {
+    ...state,
+    [category]: {
+      ...state[category],
+      [subCategory]: current,
     },
   }
 }

--- a/utils/stateUtils.js
+++ b/utils/stateUtils.js
@@ -64,3 +64,17 @@ export function updateExistingArt(state, payload) {
     },
   }
 }
+
+export function reorderSubCategory(state, payload) {
+  if (!payload) return state
+
+  const { category, subCategory } = payload[0]
+
+  return {
+    ...state,
+    [category]: {
+      ...state[category],
+      [subCategory]: [...payload],
+    },
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds the ability for the logged in user to drag and drop the thumbnail images within a subcategory to reorder them.

Changes to the order are persisted in the database a linked-list pointer on the given artwork document.

#### New stuff:

- `useArtOrdering` custom hook for applying event handlers and giving the drag and drop interface
- `LinkedList` class for creating and updating the list ordering based on each node's next pointers
- Some additional indexes on the `Artwork` schema to improve query performance
- Added `uuid` package for toast notification identifiers
- API endpoint for updating art ordering
- New reducer actions and helper methods for handling reorders on the client side 

### What am I worried about?

#### Data integrity

Currently keeping several systems in sync with any update.  Transient errors could nerf the data relationships between the database and the storage bucket which will be difficult to track down and fix in production.  The logic is sound, and is reasonably careful about handling the case of errors in the update chain.

### Screenshots/Recordings

[Screencast from 12-10-2023 02:21:13 PM.webm](https://github.com/PsiKai/kaylasite/assets/63161310/22d0ff49-4ad6-4151-a8e4-1e6155b126cb)


### Additional context

Before merging and deployment, 2 updates need to be made in the cloud database provider:

- [ ] 1. All documents in the artwork collection need to be re-linked to ensure proper updates going forward
- [ ] 2. Replica sets need to be in place for the mongoose transactions created in this PR to work