### PR TITLE
Update frontpage carousel

### DIFF
--- a/google-client.js
+++ b/google-client.js
@@ -16,6 +16,7 @@ class GoogleClient extends Storage {
   baseStorageUrl = "https://storage.googleapis.com"
   bucketName = process.env.BUCKETNAME
   thumbBucketName = process.env.THUMBS
+  THUMBNAIL_SIZE = 500
 
   mainBucket = this.bucket(this.bucketName)
   thumbBucket = this.bucket(this.thumbBucketName)

--- a/middleware/uploader.js
+++ b/middleware/uploader.js
@@ -7,7 +7,7 @@ export const uploader = async (req, res, next) => {
   const bb = busboy({ headers: req.headers })
   const uploadPromises = []
 
-  bb.on("file", (name, file, info) => {
+  bb.on("file", (_name, file, info) => {
     const { mimeType } = info
     const [_type, extension] = mimeType.split("/")
     req.body.extension = extension
@@ -17,7 +17,7 @@ export const uploader = async (req, res, next) => {
     file.pipe(passThrough)
 
     const [fullSizeStream, thumbnailStream] = storageClient.writeStream(req.body)
-    const resizeStream = sharp().resize(null, 300).webp()
+    const resizeStream = sharp().resize(null, storageClient.THUMBNAIL_SIZE).webp()
 
     const uploadPromise = new Promise((resolve, reject) => {
       passThrough

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -1,5 +1,4 @@
 import { Router } from "express"
-import { default as _ } from "lodash"
 import bcrypt from "bcrypt"
 import { getArt } from "../artState.js"
 import { titleDesc, singleArtCopy } from "../copy/title_description.js"
@@ -7,21 +6,14 @@ import User from "../db/models/user.js"
 import { isAuthenticated } from "../middleware/auth.js"
 import { storageClient } from "../google-client.js"
 import { capitalize } from "../utils/stringUtils.js"
+import { randomArtSample } from "../utils/artUtils.js"
 
 const pageRouter = Router()
 
 pageRouter.get("/", async (_req, res) => {
-  const artWorks = await getArt()
-  const randomArt = Object.entries(artWorks).reduce((random, [_category, subcategories]) => {
-    const subCatValues = Object.values(subcategories)
-    const randomSubcatIndex = Math.floor(Math.random() * subCatValues.length)
-    const randomSubcat = subCatValues[randomSubcatIndex]
-    const randomWorkIndex = Math.floor(Math.random() * randomSubcat.length)
-    random.push(randomSubcat[randomWorkIndex])
-    return random
-  }, [])
+  const randomArt = await randomArtSample(6)
 
-  res.render("index", { randomArt, artWorks, pageCopy: titleDesc[0], path: "/" })
+  res.render("index", { randomArt, pageCopy: titleDesc[0], path: "/" })
 })
 
 pageRouter.get("/login", (_req, res) => {

--- a/utils/artUtils.js
+++ b/utils/artUtils.js
@@ -1,0 +1,35 @@
+import { getArt } from "../artState.js"
+import { randomIndex } from "./numberUtils.js"
+
+export async function randomArtSample(totalSize) {
+  const { floor, random } = Math
+  const artWorks = await getArt()
+  const subcategories = Object.values(artWorks)
+  const randomSample = []
+  const repeatMap = new Map()
+  let pointer = 0
+
+  for (let i = 0; i < totalSize; i++) {
+    const subCat = subcategories[pointer]
+    const subCatArt = Object.values(subCat)
+    const randomIndex = floor(random() * subCatArt.length)
+    randomSample.push(subCatArt[randomIndex])
+    pointer = ++pointer % (subcategories.length - 1)
+  }
+
+  for (let i = 0; i < randomSample.length; i++) {
+    let currSample = randomSample[i]
+    let currIndex = randomIndex(currSample)
+
+    for (let j = 0; j < currSample.length; j++) {
+      const { _id } = currSample[currIndex]
+      if (!repeatMap.has(_id)) {
+        repeatMap.set(_id, currSample[currIndex])
+        break
+      }
+      currIndex = randomIndex(currSample)
+    }
+  }
+
+  return [...repeatMap.values()]
+}

--- a/utils/numberUtils.js
+++ b/utils/numberUtils.js
@@ -9,3 +9,7 @@ export function roundedBytes(bytes) {
 
   return bytes.toFixed(2) + " " + magnitudeScale[magnitude] + "B"
 }
+
+export function randomIndex(arr) {
+  return Math.floor(Math.random() * arr.length)
+}

--- a/views/partials/carousel.ejs
+++ b/views/partials/carousel.ejs
@@ -4,7 +4,7 @@
      	<% randomArt.forEach((artWork, i) => { %>
       <div class="carousel-item container-fluid <%= i === 0 ? 'active' : ''%>">
         	<a href="<%= artWork.category %>#<%= artWork.title %>">
-            <img loading="lazy" class="img-fluid" src="<%= artWork.thumbnail %>" alt="<%= artWork.title %>" class="d-block w-100"/>
+            <img class="img-fluid" src="<%= artWork.thumbnail %>" alt="<%= artWork.title %>" class="d-block w-100"/>
 					</a>
       	</div>
     	<% }) %>


### PR DESCRIPTION
### What changed

- Creates random art sampling utility function
- Updates route handler to use new util with a 6 artwork sample size
- Updates carousel img tags to remove lazy loading
  - This is no longer needed since I'm not loading the entire collection anymore
- Adds storage client attribute for thumbnail size
   - Sets the new size from 300 to 500

### In the background

I ran a script to resize all existing thumbnails in the bucket to the new thumbnail size  